### PR TITLE
fix redis adapter cache key

### DIFF
--- a/adapter/redis/redis.go
+++ b/adapter/redis/redis.go
@@ -29,7 +29,7 @@ import (
 
 	redisCache "github.com/go-redis/cache"
 	"github.com/go-redis/redis"
-	"github.com/victorspringer/http-cache"
+	cache "github.com/victorspringer/http-cache"
 	"github.com/vmihailenco/msgpack"
 )
 
@@ -44,7 +44,7 @@ type RingOptions redis.RingOptions
 // Get implements the cache Adapter interface Get method.
 func (a *Adapter) Get(key uint64) ([]byte, bool) {
 	var c []byte
-	if err := a.store.Get(string(key), &c); err == nil {
+	if err := a.store.Get(cache.KeyAsString(key), &c); err == nil {
 		return c, true
 	}
 
@@ -54,7 +54,7 @@ func (a *Adapter) Get(key uint64) ([]byte, bool) {
 // Set implements the cache Adapter interface Set method.
 func (a *Adapter) Set(key uint64, response []byte, expiration time.Time) {
 	a.store.Set(&redisCache.Item{
-		Key:        string(key),
+		Key:        cache.KeyAsString(key),
 		Object:     response,
 		Expiration: expiration.Sub(time.Now()),
 	})
@@ -62,7 +62,7 @@ func (a *Adapter) Set(key uint64, response []byte, expiration time.Time) {
 
 // Release implements the cache Adapter interface Release method.
 func (a *Adapter) Release(key uint64) {
-	a.store.Delete(string(key))
+	a.store.Delete(cache.KeyAsString(key))
 }
 
 // NewAdapter initializes Redis adapter.

--- a/cache.go
+++ b/cache.go
@@ -34,6 +34,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -172,6 +173,11 @@ func sortURLParams(URL *url.URL) {
 		})
 	}
 	URL.RawQuery = params.Encode()
+}
+
+// KeyAsString can be used by adapters to convert the cache key from uint64 to string.
+func KeyAsString(key uint64) string {
+	return strconv.FormatUint(key, 36)
 }
 
 func generateKey(URL string) uint64 {

--- a/cache_test.go
+++ b/cache_test.go
@@ -239,6 +239,25 @@ func TestSortURLParams(t *testing.T) {
 	}
 }
 
+func TestGenerateKeyString(t *testing.T) {
+	urls := []string{
+		"http://localhost:8080/category",
+		"http://localhost:8080/category/morisco",
+		"http://localhost:8080/category/mourisquinho",
+	}
+
+	keys := make(map[string]string, len(urls))
+	for _, u := range urls {
+		rawKey := generateKey(u)
+		key := KeyAsString(rawKey)
+
+		if otherURL, found := keys[key]; found {
+			t.Fatalf("URLs %s and %s share the same key %s", u, otherURL, key)
+		}
+		keys[key] = u
+	}
+}
+
 func TestGenerateKey(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
type conversion from uint64 to string was generating broken keys.
Probably this kind of conversion will be frequently used, so was exported to th emain package.