### PR TITLE
Add Ability to provide non-cacheable headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ func main() {
         cache.ClientWithAdapter(memcached),
         cache.ClientWithTTL(10 * time.Minute),
         cache.ClientWithRefreshKey("opn"),
+        cache.ClientWithNonCachedHeaders([]string{"geo-country"}),
     )
     if err != nil {
         fmt.Println(err)


### PR DESCRIPTION
What do you think about this feature?

It's useful when you get a header from a proxy-server with request's country and you have to keep different responses for different countries.