### PR TITLE
Update redis example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ import (
             "server": ":6379",
         },
     }
-    cacheClient := cache.NewClient(
+    cacheClient, err := cache.NewClient(
         cache.ClientWithAdapter(redis.NewAdapter(ringOpt)),
         cache.ClientWithTTL(10 * time.Minute),
         cache.ClientWithRefreshKey("opn"),


### PR DESCRIPTION
`cache.NewClient` returns both a client _and_ error. Updating README to fix this.