### PR TITLE
fix race condition in memoryadapter set

### DIFF
--- a/adapter/memory/benchmark/benchmark_comparison_test.go
+++ b/adapter/memory/benchmark/benchmark_comparison_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func BenchmarkHTTPCacheMamoryAdapterSet(b *testing.B) {
 func BenchmarkBigCacheSet(b *testing.B) {
 	cache := initBigCache(b.N)
 	for i := 0; i < b.N; i++ {
-		cache.Set(string(i), value())
+		cache.Set(strconv.Itoa(i), value())
 	}
 }
 
@@ -43,12 +44,12 @@ func BenchmarkBigCacheGet(b *testing.B) {
 	b.StopTimer()
 	cache := initBigCache(b.N)
 	for i := 0; i < b.N; i++ {
-		cache.Set(string(i), value())
+		cache.Set(strconv.Itoa(i), value())
 	}
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		cache.Get(string(i))
+		cache.Get(strconv.Itoa(i))
 	}
 }
 
@@ -74,7 +75,7 @@ func BenchmarkBigCacheSetParallel(b *testing.B) {
 		id := rand.Intn(1000)
 		counter := 0
 		for pb.Next() {
-			cache.Set(string(parallelKey(id, counter)), value())
+			cache.Set(strconv.FormatUint(parallelKey(id, counter), 10), value())
 			counter = counter + 1
 		}
 	})
@@ -101,14 +102,14 @@ func BenchmarkBigCacheGetParallel(b *testing.B) {
 	b.StopTimer()
 	cache := initBigCache(b.N)
 	for i := 0; i < b.N; i++ {
-		cache.Set(string(i), value())
+		cache.Set(strconv.Itoa(i), value())
 	}
 
 	b.StartTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		counter := 0
 		for pb.Next() {
-			cache.Get(string(counter))
+			cache.Get(strconv.Itoa(counter))
 			counter = counter + 1
 		}
 	})

--- a/adapter/memory/benchmark/benchmark_gc_overhead.go
+++ b/adapter/memory/benchmark/benchmark_gc_overhead.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"time"
 
 	"github.com/allegro/bigcache"
@@ -65,11 +66,11 @@ func benchmarkBigCache() {
 
 	for i := 0; i < entries; i++ {
 		key, val := generateKeyValue(i, valueSize)
-		bigcache.Set(string(key), val)
+		bigcache.Set(strconv.Itoa(key), val)
 	}
 
 	firstKey, _ := generateKeyValue(1, valueSize)
-	checkFirstElement(bigcache.Get(string(firstKey)))
+	checkFirstElement(bigcache.Get(strconv.Itoa(firstKey)))
 
 	fmt.Println("GC pause for bigcache: ", gcPause())
 


### PR DESCRIPTION
There were some race conditions in this function:
- iterating over map without holding the read lock (panics if some other goroutine is updating the map).
- two concurrent Set calls could "step over" the capacity check (spotted by @gkawamoto)

Added a test to spot both issues.

Also updated the benchmarks to use `strconv.Atoi` instead of string for converting from int to string, modern go doesn't support that conversion.