### PR TITLE
Additional functionality to Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /vendor/
+.idea/
+.vs/
+.vscode/

--- a/cache.go
+++ b/cache.go
@@ -164,6 +164,18 @@ func (c *Client) Drop(r *http.Request) {
 	params := r.URL.Query()
 	key := generateKey(r.URL.String())
 
+	if r.Method == http.MethodPost && r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		defer r.Body.Close()
+		if err != nil {
+			return
+		}
+
+		reader := io.NopCloser(bytes.NewBuffer(body))
+		key = generateKeyWithBody(r.URL.String(), body)
+		r.Body = reader
+	}
+
 	if _, ok := params[c.refreshKey]; ok {
 		delete(params, c.refreshKey)
 


### PR DESCRIPTION
This PR contains two additional member functions for the cache client I made for my own purposes. Figured perhaps others may find them useful.

In some cases, you may want the cache client to propagate through the system to your handlers, or other business logic. In some cases such as PUTs, or DELETEs to your system on an object, you may want the option to tell the adapter to drop the cache for the requested endpoint so clients do not get served old data (unless they used an Expires header). The `Drop` function allows for this by not having to worry about the way in which the key is generated.

Secondly, you may want to apply a client option at a later time, or change it, which isn't currently possible to do. In my use case, I have a middleware for my router which will apply different TTLs for different endpoints, as well as optionally set the Expires header for them. I deference the client pointer, and apply a change to its options for the lifecycle of that request via the `AddOptions` func.